### PR TITLE
Use relative_url filter instead of prepending base url

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -43,7 +43,7 @@ defaults:
     values:
       author: "C.S. Rhymes"
       layout: post
-      image: https://picsum.photos/id/16/1200/800
+      image: /img/home.jpg
       show_sidebar: true
   - scope:
       path: ""

--- a/_config.yml
+++ b/_config.yml
@@ -43,7 +43,7 @@ defaults:
     values:
       author: "C.S. Rhymes"
       layout: post
-      image: /img/home.jpg
+      image: https://picsum.photos/id/16/1200/800
       show_sidebar: true
   - scope:
       path: ""

--- a/_includes/author-media.html
+++ b/_includes/author-media.html
@@ -2,10 +2,10 @@
   <div class="card-content">
     <div class="media">
       <figure class="media-left">
-        <a href="{{ author.url | prepend: site.baseurl }}" class="avatar-link">
+        <a href="{{ author.url | relative_url }}" class="avatar-link">
           <p class="image is-64x64">
             {% if author.avatar %}
-              <img src="{{ author.avatar | prepend: site.baseurl }}" alt="{{ author.name }}">
+              <img src="{{ author.avatar | relative_url }}" alt="{{ author.name }}">
             {% else %}
               <i class="fas fa-user fa-4x"></i>
             {% endif %}
@@ -13,7 +13,7 @@
         </a>
       </figure>
       <div class="media-content">
-        <a href="{{ author.url | prepend: site.baseurl }}" class="is-block">
+        <a href="{{ author.url | relative_url }}" class="is-block">
           <p class="title is-5">{{ author.name }}</p>
         </a>
 

--- a/_includes/hero.html
+++ b/_includes/hero.html
@@ -1,7 +1,7 @@
 <section
   class="hero {% if page.hero_height %} {{ page.hero_height }} {% else %} is-medium {% endif %} is-bold is-dark"
   {% if page.image %}
-    style="background: url('{{ page.image | prepend: site.baseurl }}') no-repeat center center; background-size: cover;"
+    style="background: url('{{ page.image | relative_url }}') no-repeat center center; background-size: cover;"
   {% endif %}
 >
   <div class="hero-body">

--- a/_includes/post-item.html
+++ b/_includes/post-item.html
@@ -1,6 +1,6 @@
 <div class="card">
   <div class="card-image">
-    <img src="{{ post.image | prepend: site.baseurl }}" alt="{{ post.title }}" width="100%">
+    <img src="{{ post.image | relative_url }}" alt="{{ post.title }}" width="100%">
   </div>
   <div class="card-content">
     <div class="content">

--- a/_layouts/author.html
+++ b/_layouts/author.html
@@ -7,7 +7,7 @@ layout: default
   <div class="column is-3">
     {% if page.avatar %}
       <p class="image is-square">
-        <img src="{{ page.avatar | prepend: site.baseurl }}" alt="{{ page.name }}">
+        <img src="{{ page.avatar | relative_url }}" alt="{{ page.name }}">
       </p>
     {% else %}
       <div class="has-text-centered">
@@ -46,7 +46,7 @@ layout: default
         <div class="column is-12">
           <div class="card">
             <div class="card-content">
-              <a href="{{ post.url | prepend: site.baseurl }}" class="is-block">
+              <a href="{{ post.url | relative_url }}" class="is-block">
                 <p class="title is-5">{{ post.title }}</p>
               </a>
 
@@ -55,11 +55,10 @@ layout: default
                 <p>{{ post.excerpt | strip_html | strip_newlines | truncate: 100 }}</p>
               </div>
             </div>
-            {% comment %}
-              <div class="card-footer">
-                <a href="{{ post.url | prepend: site.baseurl }}" class="button is-dark card-footer-item">Read more</a>
-              </div>
-            {% endcomment %}
+
+            <div class="card-footer">
+              <a href="{{ post.url | relative_url }}" class="button is-dark card-footer-item">Read more</a>
+            </div>
           </div>
         </div>
       {% endfor %}

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -7,7 +7,7 @@ layout: default
       {% if page.intro_image %}
         <div class="column is-8-desktop is-6-tablet">
           <figure class="image {% if page.intro_image_ratio %} {{ page.intro_image_ratio }} {% else %} is-16by9 {% endif %}">
-            <img src="{{ page.intro_image | prepend: site.baseurl }}" alt="{{ page.title }}">
+            <img src="{{ page.intro_image | relative_url }}" alt="{{ page.title }}">
           </figure>
         </div>
       {% endif %}

--- a/_posts/2019-09-01-second-post.md
+++ b/_posts/2019-09-01-second-post.md
@@ -1,6 +1,7 @@
 ---
 layout: post
 title: Second Post
+image: https://picsum.photos/id/57/1200/800
 ---
 
 Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec elit eros, porta eget dapibus vitae, tempus et mi. Maecenas sollicitudin ligula vel metus condimentum, ac commodo sem vestibulum. Morbi tempus dui sapien, vel mattis orci faucibus id. Nulla congue elit vel accumsan mattis. Ut vel dolor porttitor, laoreet risus in, tempus velit. Praesent eu nisi enim. Integer sed venenatis risus, eget semper sapien. Nulla at lacinia lectus. Sed rutrum lectus at vestibulum tristique. Cras ex sem, consequat at dapibus scelerisque, iaculis sit amet tellus. Fusce eu orci ut ex consequat semper. Mauris pharetra dictum dui, vestibulum egestas erat.

--- a/_posts/2019-09-02-third-post.md
+++ b/_posts/2019-09-02-third-post.md
@@ -1,6 +1,7 @@
 ---
 layout: post
 title: Third Post
+image: https://picsum.photos/id/66/1200/800
 ---
 
 Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec elit eros, porta eget dapibus vitae, tempus et mi. Maecenas sollicitudin ligula vel metus condimentum, ac commodo sem vestibulum. Morbi tempus dui sapien, vel mattis orci faucibus id. Nulla congue elit vel accumsan mattis. Ut vel dolor porttitor, laoreet risus in, tempus velit. Praesent eu nisi enim. Integer sed venenatis risus, eget semper sapien. Nulla at lacinia lectus. Sed rutrum lectus at vestibulum tristique. Cras ex sem, consequat at dapibus scelerisque, iaculis sit amet tellus. Fusce eu orci ut ex consequat semper. Mauris pharetra dictum dui, vestibulum egestas erat.

--- a/_posts/2019-09-03-fourth-post.md
+++ b/_posts/2019-09-03-fourth-post.md
@@ -1,6 +1,7 @@
 ---
 layout: post
 title: Fourth Post
+image: https://picsum.photos/id/62/1200/800
 ---
 
 Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec elit eros, porta eget dapibus vitae, tempus et mi. Maecenas sollicitudin ligula vel metus condimentum, ac commodo sem vestibulum. Morbi tempus dui sapien, vel mattis orci faucibus id. Nulla congue elit vel accumsan mattis. Ut vel dolor porttitor, laoreet risus in, tempus velit. Praesent eu nisi enim. Integer sed venenatis risus, eget semper sapien. Nulla at lacinia lectus. Sed rutrum lectus at vestibulum tristique. Cras ex sem, consequat at dapibus scelerisque, iaculis sit amet tellus. Fusce eu orci ut ex consequat semper. Mauris pharetra dictum dui, vestibulum egestas erat.

--- a/_posts/2019-09-04-fifth-post.md
+++ b/_posts/2019-09-04-fifth-post.md
@@ -3,6 +3,7 @@ layout: post
 title: Fifth Post
 author: Dave Mc Dave
 intro: This is the intro for this post. This post has no intro image, just text
+image: https://picsum.photos/id/95/1200/800
 ---
 
 Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec elit eros, porta eget dapibus vitae, tempus et mi. Maecenas sollicitudin ligula vel metus condimentum, ac commodo sem vestibulum. Morbi tempus dui sapien, vel mattis orci faucibus id. Nulla congue elit vel accumsan mattis. Ut vel dolor porttitor, laoreet risus in, tempus velit. Praesent eu nisi enim. Integer sed venenatis risus, eget semper sapien. Nulla at lacinia lectus. Sed rutrum lectus at vestibulum tristique. Cras ex sem, consequat at dapibus scelerisque, iaculis sit amet tellus. Fusce eu orci ut ex consequat semper. Mauris pharetra dictum dui, vestibulum egestas erat.

--- a/_posts/2019-09-05-sixth-post.md
+++ b/_posts/2019-09-05-sixth-post.md
@@ -4,8 +4,9 @@ title: Post with Intro
 author: Guest Author
 description: This is a post with an introduction image and text
 intro: This is the introduction text for this post. It appears large and bold at the top of the post!
-intro_image: /img/home.jpg
+intro_image: https://picsum.photos/id/112/1200/800
 intro_image_ratio: is-16by9
+image: https://picsum.photos/id/109/1200/800
 ---
 
 Version 0.3 allows you to provide a intro and an intro image. When creating your post add a short `intro` text an `intro_image` as a path to an image and then specify the `intro_image_ratio` which should be a [Bulma image](https://bulma.io/documentation/elements/image/) class.

--- a/mere-blog-theme.gemspec
+++ b/mere-blog-theme.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |spec|
   spec.name          = "mere-blog-theme"
-  spec.version       = "1.0"
+  spec.version       = "1.0.1"
   spec.authors       = ["chrisrhymes"]
   spec.email         = ["csrhymes@gmail.com"]
 


### PR DESCRIPTION
Replace the use of prepend: base_url with the [relative_url filter](https://jekyllrb.com/docs/liquid/filters/). This allows images from another source to be used, such as lorem picsum. 